### PR TITLE
feat: add global title management with dynamic page titles

### DIFF
--- a/client/app/layout.tsx
+++ b/client/app/layout.tsx
@@ -12,7 +12,10 @@ import Script from 'next/script';
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
-  title: "Valcheq Technologies",
+  title: {
+    default: "Valcheq Technologies",
+    template: "%s | Valcheq Technologies",
+  },
   description:
     "Empowering businesses with cutting-edge web development, data analytics, and AI solutions. Valcheq Technologies offers custom website and app development, data analysis services, chatbots and AI-powered applications.",
 };

--- a/client/app/privacy-policy/page.tsx
+++ b/client/app/privacy-policy/page.tsx
@@ -1,3 +1,9 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy",
+};
+
 export default function PrivacyPolicyPage() {
     return (
       <div className="container mx-auto px-4 py-16 max-w-4xl">


### PR DESCRIPTION
- Added `metadata` configuration in `layout.tsx` to handle default and template titles
  - Default title: "Valcheq Technologies"
  - Template: "%s | Valcheq Technologies" for dynamic page titles
- Updated `privacy-policy` page to use `metadata` for setting its title
- Ensures consistent and dynamic page titles across the application