### PR TITLE
fix: correct 'Contact Us Today' button navigation to homepage contact section

### DIFF
--- a/client/app/services/page.tsx
+++ b/client/app/services/page.tsx
@@ -146,7 +146,7 @@ export default function ServicesPage() {
           <h2 className="text-3xl font-bold mb-6 text-center text-blue-800">Ready to Transform Your Business?</h2>
           <p className="text-center mb-8 text-gray-600">Let&apos;s discuss how our services can help you achieve your goals.</p>
           <div className="text-center">
-            <Link href="/contact" className="bg-blue-600 text-white px-6 py-3 rounded-md hover:bg-blue-700 transition-colors">
+            <Link href="/#contact" className="bg-blue-600 text-white px-6 py-3 rounded-md hover:bg-blue-700 transition-colors">
               Contact Us Today
             </Link>
           </div>


### PR DESCRIPTION
- Updated the `href` attribute of the 'Contact Us Today' button from `/contact` to `/#contact`.
- Ensured the button redirects users to the homepage's contact section (`/#contact`) instead of a non-existent `/contact` page.
- Resolved the issue where clicking the button from the `/services` page incorrectly attempted to navigate to `/services/#contact`.